### PR TITLE
treat 'activating' state as unhealthy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coco Fleet Unit Healthcheck
 
+[![Circle CI](https://circleci.com/gh/Financial-Times/coco-fleet-unit-healthcheck/tree/master.png?style=shield)](https://circleci.com/gh/Financial-Times/coco-fleet-unit-healthcheck/tree/master)
+
 Uses fleet api to look at all the units running in the cluster which are in a failed state.
 
 ## Building

--- a/fleet-unit-healthcheck.go
+++ b/fleet-unit-healthcheck.go
@@ -106,6 +106,10 @@ func (f *fleetUnitHealthChecker) Check(unitState schema.UnitState) error {
 		return errors.New("Unit is in failed state.")
 	}
 
+	if "activating" == unitState.SystemdActiveState {
+		return errors.New("Unit is in activating state.")
+	}
+
 	if "inactive" == unitState.SystemdActiveState && !isServiceWhitelisted(unitState.Name, f.whitelist) {
 		return errors.New("Unit is in inactive state.")
 	}

--- a/fleet-unit-healthcheck_test.go
+++ b/fleet-unit-healthcheck_test.go
@@ -21,6 +21,10 @@ func TestCheck(t *testing.T) {
 			"Unit is in failed state.",
 		},
 		{
+			schema.UnitState{SystemdActiveState: "activating"},
+			"Unit is in activating state.",
+		},
+		{
 			schema.UnitState{Name: "vulcan.service", SystemdActiveState: "inactive"},
 			"Unit is in inactive state.",
 		},


### PR DESCRIPTION
Currently we do not monitor the services which are periodically trying to get started, but can't because of docker issues (or something else).
This is a fix for alerting in case of these events.
